### PR TITLE
 Fix parsing error due to required field in VideoFocusRequest

### DIFF
--- a/aasdk_proto/VideoFocusRequestMessage.proto
+++ b/aasdk_proto/VideoFocusRequestMessage.proto
@@ -25,7 +25,7 @@ package f1x.aasdk.proto.messages;
 
 message VideoFocusRequest
 {
-    required int32 disp_index = 1;
+    optional int32 disp_index = 1;
     required enums.VideoFocusMode.Enum focus_mode = 2;
     required enums.VideoFocusReason.Enum focus_reason = 3;
 }


### PR DESCRIPTION
This fixes the issue described at https://github.com/opencardev/crankshaft/issues/357, where the screen would freeze when the "Return to ..." button was pressed.